### PR TITLE
[GTASA] Wrapped update-function in try-catch to fix crashing on Linux

### DIFF
--- a/GTASA.asl
+++ b/GTASA.asl
@@ -987,28 +987,35 @@ init
 
 update
 {
-	//=============================================================================
-	// General Housekeeping
-	//=============================================================================
-	// Disable all timer control actions if version was not detected
-	if (!vars.enabled)
-		return false;
-
-	// Update always, to prevent splitting after loading (if possible, doesn't seem to be 100% reliable)
-	vars.watchers.UpdateAll(game);
-
-	// Clear list of already executed splits if timer is reset
-	if (timer.CurrentPhase != vars.PrevPhase)
+	try
 	{
-		if (timer.CurrentPhase == TimerPhase.NotRunning)
-		{
-			vars.split.Clear();
-			vars.DebugOutput("Cleared list of already executed splits");
-		}
-		vars.PrevPhase = timer.CurrentPhase;
-	}
+		//=============================================================================
+		// General Housekeeping
+		//=============================================================================
+		// Disable all timer control actions if version was not detected
+		if (!vars.enabled)
+			return false;
 
-	//print(vars.watchers["pedStatus"].Current.ToString());
+		// Update always, to prevent splitting after loading (if possible, doesn't seem to be 100% reliable)
+		vars.watchers.UpdateAll(game);
+
+		// Clear list of already executed splits if timer is reset
+		if (timer.CurrentPhase != vars.PrevPhase)
+		{
+			if (timer.CurrentPhase == TimerPhase.NotRunning)
+			{
+				vars.split.Clear();
+				vars.DebugOutput("Cleared list of already executed splits");
+			}
+			vars.PrevPhase = timer.CurrentPhase;
+		}
+
+		//print(vars.watchers["pedStatus"].Current.ToString());
+	}
+	catch
+	{
+		return false;
+	}
 }
 
 split


### PR DESCRIPTION
Autosplitter works othewise fine, but if SA crashes or you need to reset, Livesplit crashed and froze ~8 times out of 10 either when SA's exe closed or started. Because apparently under Linux, if the Autosplitter throws an exception, it crashes the whole LiveSplit (source: [Autosplitters on Linux blogpost](https://delcake.com/journal/linux/livesplit-autosplitters-on-linux-systems)).

Wrapping the update-function in try-catch and just returning false on catch seems to fix the issue completely and this shouldn't affect the normal operation of the Autosplitter.